### PR TITLE
feat: Add Google Analytics to portfolio

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -11,6 +11,14 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.1.2/css/all.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-57FDS7T2VC"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-57FDS7T2VC');
+    </script>
     <script
     type="text/javascript"
     src="https://cdn.jsdelivr.net/npm/@emailjs/browser@4/dist/email.min.js"></script>


### PR DESCRIPTION
## Description
This pull request adds Google Analytics to the portfolio by including the Google Tag Manager script in the head of the `layout.erb` page. The changes include:

- Adding the Google Tag Manager script to the <head> section of the layout file to ensure it is included on all pages.

## Changes made
Added Google Tag Manager Script:
Included the Google Tag Manager script in the <head> section of the `layout.erb` file to enable Google Analytics tracking across all pages.

## Checklist

- [x] Ensure the Google Tag Manager script is correctly added to the <head> section.
- [x] Verify that Google Analytics is tracking visits across all pages.
- [x] Test the deployment to ensure the script is included on all pages.